### PR TITLE
add foundry contract + minor tweak on displaying of error message

### DIFF
--- a/extension/packages/foundry/contracts/NFTContract.sol
+++ b/extension/packages/foundry/contracts/NFTContract.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+
+/**
+ * @title NFTContract
+ * @dev A simple ERC-721 contract example with SVG support
+ */
+contract NFTContract is ERC721Enumerable {
+    uint256 public nextTokenId;
+
+    constructor() ERC721("smileNFT", "SNFT") {}
+
+    /**
+     * @dev Mints a new token to the specified address
+     * @param to The address to mint the token to
+     */
+    function mint(address to) external {
+        _mint(to, nextTokenId);
+        nextTokenId++;
+    }
+
+    /**
+     * @dev Returns an array of token IDs owned by the given address
+     * @param owner The address to query
+     * @return uint256[] List of token IDs owned by the address
+     */
+    function tokensOfOwner(address owner) external view returns (uint256[] memory) {
+        uint256 tokenCount = balanceOf(owner);
+        uint256[] memory tokenIds = new uint256[](tokenCount);
+        for (uint256 i = 0; i < tokenCount; i++) {
+            tokenIds[i] = tokenOfOwnerByIndex(owner, i);
+        }
+        return tokenIds;
+    }
+
+    /**
+     * @dev Returns the token URI for a given token ID
+     * @param tokenId The token ID
+     * @return The token URI
+     */
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        string memory svg = generateSVG();
+        string memory json = string(
+            abi.encodePacked(
+                '{"name": "Smiley face NFT", "description": "A simple smiley face SVG NFT", "image": "',
+                svg,
+                '"}'
+            )
+        );
+        return json;  // Return the plain JSON string instead of a data URI
+    }
+
+    /**
+     * @dev Generates the SVG for the cat
+     * @return The SVG string
+     */
+    function generateSVG() internal pure returns (string memory) {
+        return 
+            string(abi.encodePacked(
+                '<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 100 100\\">',
+                '<circle cx=\\"50\\" cy=\\"50\\" r=\\"50\\" fill=\\"gray\\" />',
+                '<circle cx=\\"35\\" cy=\\"35\\" r=\\"5\\" fill=\\"black\\" />',
+                '<circle cx=\\"65\\" cy=\\"35\\" r=\\"5\\" fill=\\"black\\" />',
+                '<path d=\\"M 35 65 Q 50 80 65 65\\" stroke=\\"black\\" stroke-width=\\"5\\" fill=\\"none\\" />',
+                '</svg>'
+            ));
+    }
+}

--- a/extension/packages/foundry/contracts/NFTContract.sol
+++ b/extension/packages/foundry/contracts/NFTContract.sol
@@ -8,63 +8,68 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
  * @dev A simple ERC-721 contract example with SVG support
  */
 contract NFTContract is ERC721Enumerable {
-    uint256 public nextTokenId;
+  uint256 public nextTokenId;
 
-    constructor() ERC721("smileNFT", "SNFT") {}
+  constructor() ERC721("smileNFT", "SNFT") { }
 
-    /**
-     * @dev Mints a new token to the specified address
-     * @param to The address to mint the token to
-     */
-    function mint(address to) external {
-        _mint(to, nextTokenId);
-        nextTokenId++;
+  /**
+   * @dev Mints a new token to the specified address
+   * @param to The address to mint the token to
+   */
+  function mint(address to) external {
+    _mint(to, nextTokenId);
+    nextTokenId++;
+  }
+
+  /**
+   * @dev Returns an array of token IDs owned by the given address
+   * @param owner The address to query
+   * @return uint256[] List of token IDs owned by the address
+   */
+  function tokensOfOwner(
+    address owner
+  ) external view returns (uint256[] memory) {
+    uint256 tokenCount = balanceOf(owner);
+    uint256[] memory tokenIds = new uint256[](tokenCount);
+    for (uint256 i = 0; i < tokenCount; i++) {
+      tokenIds[i] = tokenOfOwnerByIndex(owner, i);
     }
+    return tokenIds;
+  }
 
-    /**
-     * @dev Returns an array of token IDs owned by the given address
-     * @param owner The address to query
-     * @return uint256[] List of token IDs owned by the address
-     */
-    function tokensOfOwner(address owner) external view returns (uint256[] memory) {
-        uint256 tokenCount = balanceOf(owner);
-        uint256[] memory tokenIds = new uint256[](tokenCount);
-        for (uint256 i = 0; i < tokenCount; i++) {
-            tokenIds[i] = tokenOfOwnerByIndex(owner, i);
-        }
-        return tokenIds;
-    }
+  /**
+   * @dev Returns the token URI for a given token ID
+   * @param tokenId The token ID
+   * @return The token URI
+   */
+  function tokenURI(
+    uint256 tokenId
+  ) public view override returns (string memory) {
+    string memory svg = generateSVG();
+    string memory json = string(
+      abi.encodePacked(
+        '{"name": "Smiley face NFT", "description": "A simple smiley face SVG NFT", "image": "',
+        svg,
+        '"}'
+      )
+    );
+    return json; // Return the plain JSON string instead of a data URI
+  }
 
-    /**
-     * @dev Returns the token URI for a given token ID
-     * @param tokenId The token ID
-     * @return The token URI
-     */
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
-        string memory svg = generateSVG();
-        string memory json = string(
-            abi.encodePacked(
-                '{"name": "Smiley face NFT", "description": "A simple smiley face SVG NFT", "image": "',
-                svg,
-                '"}'
-            )
-        );
-        return json;  // Return the plain JSON string instead of a data URI
-    }
-
-    /**
-     * @dev Generates the SVG for the cat
-     * @return The SVG string
-     */
-    function generateSVG() internal pure returns (string memory) {
-        return 
-            string(abi.encodePacked(
-                '<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 100 100\\">',
-                '<circle cx=\\"50\\" cy=\\"50\\" r=\\"50\\" fill=\\"gray\\" />',
-                '<circle cx=\\"35\\" cy=\\"35\\" r=\\"5\\" fill=\\"black\\" />',
-                '<circle cx=\\"65\\" cy=\\"35\\" r=\\"5\\" fill=\\"black\\" />',
-                '<path d=\\"M 35 65 Q 50 80 65 65\\" stroke=\\"black\\" stroke-width=\\"5\\" fill=\\"none\\" />',
-                '</svg>'
-            ));
-    }
+  /**
+   * @dev Generates the SVG for the cat
+   * @return The SVG string
+   */
+  function generateSVG() internal pure returns (string memory) {
+    return string(
+      abi.encodePacked(
+        '<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 100 100\\">',
+        '<circle cx=\\"50\\" cy=\\"50\\" r=\\"50\\" fill=\\"gray\\" />',
+        '<circle cx=\\"35\\" cy=\\"35\\" r=\\"5\\" fill=\\"black\\" />',
+        '<circle cx=\\"65\\" cy=\\"35\\" r=\\"5\\" fill=\\"black\\" />',
+        '<path d=\\"M 35 65 Q 50 80 65 65\\" stroke=\\"black\\" stroke-width=\\"5\\" fill=\\"none\\" />',
+        "</svg>"
+      )
+    );
+  }
 }

--- a/extension/packages/foundry/script/Deploy.s.sol.args.mjs
+++ b/extension/packages/foundry/script/Deploy.s.sol.args.mjs
@@ -3,7 +3,7 @@ export const deploymentsLogic = `
 
     vm.startBroadcast(deployerPrivateKey);
 
-    NFTContarct nftContract = new NFTContract();
+    NFTContract nftContract = new NFTContract();
     console.logString(string.concat("NFTContract deployed at: ", vm.toString(address(nftContract))));
 
     vm.stopBroadcast();

--- a/extension/packages/foundry/script/Deploy.s.sol.args.mjs
+++ b/extension/packages/foundry/script/Deploy.s.sol.args.mjs
@@ -1,0 +1,11 @@
+export const deploymentsScriptsImports = `import "../contracts/NFTContract.sol";`;
+export const deploymentsLogic = `
+
+    vm.startBroadcast(deployerPrivateKey);
+
+    NFTContarct nftContract = new NFTContract();
+    console.logString(string.concat("NFTContract deployed at: ", vm.toString(address(nftContract))));
+
+    vm.stopBroadcast();
+
+`;

--- a/extension/packages/nextjs/app/nft/page.tsx
+++ b/extension/packages/nextjs/app/nft/page.tsx
@@ -4,14 +4,10 @@ import { useEffect, useState } from "react";
 import type { NextPage } from "next";
 import { useAccount } from "wagmi";
 import { Address, AddressInput } from "~~/components/scaffold-eth";
-import {
-  useDeployedContractInfo,
-  useScaffoldReadContract,
-  useScaffoldWriteContract,
-  useTransactor,
-} from "~~/hooks/scaffold-eth";
+import { useDeployedContractInfo, useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { getParsedError } from "~~/utils/scaffold-eth";
 
-const Home: NextPage = () => {
+const NFT: NextPage = () => {
   const { data: nftContractData } = useDeployedContractInfo("NFTContract");
   const { address: connectedAddress } = useAccount();
   const [recipientAddress, setRecipientAddress] = useState<string>("");
@@ -55,11 +51,7 @@ const Home: NextPage = () => {
       setTransactionHash(result); // Only set transaction hash if successful
       console.log("Transaction successful:", result);
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        setErrorMessage(e.message);
-      } else {
-        setErrorMessage("An unexpected error occurred.");
-      }
+      setErrorMessage(getParsedError(e));
       console.error("Error minting NFT:", e);
     }
   };
@@ -118,7 +110,7 @@ const Home: NextPage = () => {
   );
 };
 
-export default Home;
+export default NFT;
 
 const NFTDisplay: React.FC<{ tokenId: string }> = ({ tokenId }) => {
   const { data: tokenURI } = useScaffoldReadContract({


### PR DESCRIPTION
### Description: 

- Adds foundry directory so people can choose b/w hardhat nd foundry 
  <details>
    <summary>
    Example : 
    </summary>
    
    ![Screenshot 2024-09-01 at 1 01 08 PM](https://github.com/user-attachments/assets/3bbf4642-8c0f-44da-ba36-f8d0f3083317)
    
    
    </details>
    
- made a minor tweak to displaying of error message on frontend (we actually have a small util in SE-2 to parse onchain error and display them in human readable string [`getParsedError`](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/packages/nextjs/utils/scaffold-eth/getParsedError.ts) ) 

   <details>

  <summary>
  Example : 
  </summary>
      
  | Before | After | 
  | ------- | ----- | 
  | ![Screenshot 2024-09-01 at 1 11 53 PM](https://github.com/user-attachments/assets/a403cdf1-3ef9-4919-9d8c-ec1bcffa3e1d) | ![Screenshot 2024-09-01 at 1 12 16 PM](https://github.com/user-attachments/assets/d0779b36-1e45-4b49-a703-1b0998434789) | 
  
  
  </details>


### Test: 

```shell
npx create-eth@latest -e technophile-04/se2-erc721-extension:foundry-minor-tweaks
```

